### PR TITLE
CSI-1123 fix flowstatus for add coins verify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cypherock/protocols",
-  "version": "3.0.1-beta.36",
+  "version": "3.0.1-beta.37",
   "description": "Communication protocols for the cypherock x1 wallet",
   "main": "dist/app.js",
   "types": "dist/app.d.ts",

--- a/src/flows/addCoin/index.ts
+++ b/src/flows/addCoin/index.ts
@@ -176,7 +176,7 @@ export class CoinAdder extends CyFlow {
       expectedCommandTypes: [46, 49, 75, 76, 71, 81],
       onStatus: status => {
         if (
-          status.flowStatus >= ADD_COINS_TASKS.ADD_COINS_VERIFY &&
+          status.flowStatus > ADD_COINS_TASKS.ADD_COINS_VERIFY &&
           requestAcceptedState === 0
         ) {
           requestAcceptedState = 1;


### PR DESCRIPTION
device send flowstatus 1 when coin is in verify stage, not verified. so we desktop needs to act after that stage not in that stage